### PR TITLE
Fix maven-based Kotlin+Spek

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,12 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>1.0.6</kotlin.version>
-        <main.class>KotlinMain2Kt</main.class>
-        <spek-api.version>1.0.89</spek-api.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <kotlin.version>1.1.1</kotlin.version>
+        <junit.jupiter.version>5.0.0-M3</junit.jupiter.version>
+        <junit.platform.version>1.0.0-M3</junit.platform.version>
+        <spek-api.version>1.1.0</spek-api.version>
     </properties>
 
     <dependencies>
@@ -30,29 +33,25 @@
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-stdlib</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-reflect</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.spek</groupId>
-            <artifactId>spek-junit-platform-engine</artifactId>
-            <version>${spek-api.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>5.0-SNAPSHOT</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
-        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
-                <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
                 <executions>
                     <execution>
@@ -84,7 +83,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.6.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by maven -->
                     <execution>
@@ -112,22 +115,27 @@
                     </execution>
                 </executions>
             </plugin>
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
                     <failIfNoTests>true</failIfNoTests>
-                    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
-                    <includes>*/**Spek*</includes>
+                    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+                    <includes>
+                        <include>**/*Spek*</include>
+                    </includes>
                 </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.0.0-M3</version>
+                        <version>${junit.platform.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.spek</groupId>
+                        <artifactId>spek-junit-platform-engine</artifactId>
+                        <version>${spek-api.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/main/java/Printer.java
+++ b/src/main/java/Printer.java
@@ -2,9 +2,7 @@
  * Created by nikita on 01.02.17.
  */
 public class Printer {
-
-
-    public static String sayHello(String word){
-        return "Hello "+word;
+    public static String sayHello(String word) {
+        return "Hello, " + word;
     }
 }

--- a/src/test/kotlin/PrinterSpek.kt
+++ b/src/test/kotlin/PrinterSpek.kt
@@ -1,21 +1,21 @@
+import Printer.sayHello
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
+import org.junit.jupiter.api.Assertions.assertEquals
 
 /**
  * Created by nikita on 01.02.17.
  */
 class PrinterSpek : Spek({
-    val v = "World"
-    given("A printer "){
-        on("Word "+v){
-            val s = "'Hello, World'"
-            it("Should return $s"){
-                //TODO assert
+    val word = "World"
+    given("A printer") {
+        on("Word $word") {
+            val expected = "Hello, $word"
+            it("should return '$expected'") {
+                assertEquals(expected, sayHello(word))
             }
         }
-
     }
-
 })


### PR DESCRIPTION
```
$ mvn clean test
...
[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ maven-testing-with-kotlin ---

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Mar 29, 2017 6:35:33 PM org.junit.platform.launcher.core.ServiceLoaderTestEngineRegistry loadTestEngines
INFO: Discovered TestEngines with IDs: [spek]
Running PrinterSpek
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in PrinterSpek

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.345 s
[INFO] Finished at: 2017-03-29T18:35:34+03:00
[INFO] Final Memory: 42M/533M
[INFO] ------------------------------------------------------------------------
```